### PR TITLE
Potential fix for code scanning alert no. 31: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,4 +1,4 @@
-import json
+
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple


### PR DESCRIPTION
Potential fix for [https://github.com/lucasb/test-template-ssc/security/code-scanning/31](https://github.com/lucasb/test-template-ssc/security/code-scanning/31)

To fix the problem, we need to remove the unused import statement for the `json` module. This will eliminate the unnecessary dependency and make the code cleaner and easier to read. The change should be made in the file `src/cronk/cron_to_json.py` by deleting the line that imports the `json` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
