### PR TITLE
Potential fix for code scanning alert no. 32: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,6 +1,6 @@
 import json
 import re
-from dataclasses import dataclass, field
+
 from typing import Dict, List, Tuple
 
 from loguru import logger


### PR DESCRIPTION
Potential fix for [https://github.com/lucasb/test-template-ssc/security/code-scanning/32](https://github.com/lucasb/test-template-ssc/security/code-scanning/32)

To fix the problem, we need to remove the unused imports from the code. This will clean up the code and reduce unnecessary dependencies, making the code easier to read and maintain.

The best way to fix the problem is to delete the import statement for `dataclass` and `field` from the `dataclasses` module. This change should be made in the file `src/cronk/cron_to_json.py` on line 3.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
